### PR TITLE
Dump all constructed Buchi automata

### DIFF
--- a/pecan.py
+++ b/pecan.py
@@ -66,6 +66,7 @@ def main():
     parser.add_argument('--extract-implications', help='Alternate mode of running a program involving going through each theorem, extracting the top-level implication that needs to be checked (if applicable).', required=False, action='store_true')
     parser.add_argument('--use-var-map', help='Use the var_map from the specified file and convert the main file to use the same var map (i.e., the argument corresponding to <file>)', required=False, type=str)
     parser.add_argument('--stats', help='Write out statistics about each predicate defined and theorem tested (i.e., in save_aut and assert_prop)', required=False, action='store_true')
+    parser.add_argument('--output-hoa', help='Outputs encountered Buchi automata into the file', required=False, type=str, dest="output_hoa", metavar="HOA_FILE")
 
     args = parser.parse_args()
 
@@ -76,6 +77,7 @@ def main():
     settings.set_min_opt(args.min_opt)
     settings.set_extract_implications(args.extract_implications)
     settings.set_write_statistics(args.stats)
+    settings.set_output_hoa(args.output_hoa)
 
     if args.debug is None:
         settings.set_debug_level(0)

--- a/pecan/automata/buchi.py
+++ b/pecan/automata/buchi.py
@@ -88,7 +88,14 @@ class BuchiAutomaton(Automaton):
     def complement(self):
         if settings.get_simplication_level() > 0:
             self.postprocess()
+        self.dump_aut()
         return BuchiAutomaton(spot.complement(self.get_aut()), self.var_map)
+
+    def dump_aut(self):
+        hoa_file = settings.get_output_hoa()
+        if hoa_file:
+            with open(hoa_file, "a") as fd:
+                fd.write(self.get_aut().to_str() + "\n\n")
 
     def relabel(self):
         level_before = settings.get_simplication_level()

--- a/pecan/automata/buchi.py
+++ b/pecan/automata/buchi.py
@@ -80,16 +80,21 @@ class BuchiAutomaton(Automaton):
         return BuchiAutomaton.as_buchi(FalseAutomaton()).with_var_map(self.var_map)
 
     def conjunction(self, other):
-        return merge(spot.product, self, other)
+        result = merge(spot.product, self, other)
+        result.dump_aut()
+        return result
 
     def disjunction(self, other):
-        return merge(spot.product_or, self, other)
+        result = merge(spot.product_or, self, other)
+        result.dump_aut()
+        return result
 
     def complement(self):
         if settings.get_simplication_level() > 0:
             self.postprocess()
-        self.dump_aut()
-        return BuchiAutomaton(spot.complement(self.get_aut()), self.var_map)
+        result = BuchiAutomaton(spot.complement(self.get_aut()), self.var_map)
+        result.dump_aut()
+        return result
 
     def dump_aut(self):
         hoa_file = settings.get_output_hoa()

--- a/pecan/settings.py
+++ b/pecan/settings.py
@@ -21,6 +21,7 @@ class Settings:
         self.only_min_opt = False
         self.extract_implications = False
         self.write_statistics = False
+        self.output_hoa = None
 
         self.stdlib_prog = None
 
@@ -103,6 +104,13 @@ class Settings:
 
     def should_load_stdlib(self):
         return self.load_stdlib
+
+    def set_output_hoa(self, hoa_file):
+        self.output_hoa = hoa_file
+        return self
+
+    def get_output_hoa(self):
+        return self.output_hoa
 
     def log(self, level, msg=None):
         if msg is None:


### PR DESCRIPTION
Adds a flag to output all results of conjunction/disjunction/complement into a HOA file. Can be used to collect automata for benchmarking Buchi operations.